### PR TITLE
Remove $(DESTDIR) from the .desktop file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,8 @@ install: release
 	echo "[Desktop Entry]" > $(DESKTOP)
 	echo "Name=Polished Map" >> $(DESKTOP)
 	echo "Comment=Edit pokecrystal maps and tilesets" >> $(DESKTOP)
-	echo "Icon=$(DESTDIR)$(PREFIX)/share/pixmaps/polishedmap48.xpm" >> $(DESKTOP)
-	echo "Exec=$(DESTDIR)$(PREFIX)/bin/$(polishedmap)" >> $(DESKTOP)
+	echo "Icon=$(PREFIX)/share/pixmaps/polishedmap48.xpm" >> $(DESKTOP)
+	echo "Exec=$(PREFIX)/bin/$(polishedmap)" >> $(DESKTOP)
 	echo "Type=Application" >> $(DESKTOP)
 	echo "Terminal=false" >> $(DESKTOP)
 


### PR DESCRIPTION
The purpose of DESTDIR is to allow "mock-installing" a package to prepare for distribution through a package manager. As a consequence of this fact, the DESTDIR will not exist when the program will actually be used, and definitely shouldn't be recorded in the installed files.