### PR TITLE
Fix build using GCC on Linux

### DIFF
--- a/src/event.cpp
+++ b/src/event.cpp
@@ -128,21 +128,21 @@ static uchar texture_azure32_png_buffer[107] = {
 };
 
 static Fl_PNG_Image texture_images[NUM_EVENT_TEXTURES] = {
-	Fl_PNG_Image(NULL, texture_red16_png_buffer, 107),    // TX_RED
-	Fl_PNG_Image(NULL, texture_green16_png_buffer, 107),  // TX_GREEN
-	Fl_PNG_Image(NULL, texture_blue16_png_buffer, 107),   // TX_BLUE
-	Fl_PNG_Image(NULL, texture_purple16_png_buffer, 107), // TX_PURPLE
-	Fl_PNG_Image(NULL, texture_orange16_png_buffer, 107), // TX_ORANGE
-	Fl_PNG_Image(NULL, texture_azure16_png_buffer, 107)   // TX_AZURE
+	{NULL, texture_red16_png_buffer, 107},    // TX_RED
+	{NULL, texture_green16_png_buffer, 107},  // TX_GREEN
+	{NULL, texture_blue16_png_buffer, 107},   // TX_BLUE
+	{NULL, texture_purple16_png_buffer, 107}, // TX_PURPLE
+	{NULL, texture_orange16_png_buffer, 107}, // TX_ORANGE
+	{NULL, texture_azure16_png_buffer, 107}   // TX_AZURE
 };
 
 static Fl_PNG_Image zoomed_texture_images[NUM_EVENT_TEXTURES] = {
-	Fl_PNG_Image(NULL, texture_red32_png_buffer, 107),    // TX_RED
-	Fl_PNG_Image(NULL, texture_green32_png_buffer, 107),  // TX_GREEN
-	Fl_PNG_Image(NULL, texture_blue32_png_buffer, 107),   // TX_BLUE
-	Fl_PNG_Image(NULL, texture_purple32_png_buffer, 107), // TX_PURPLE
-	Fl_PNG_Image(NULL, texture_orange32_png_buffer, 107), // TX_ORANGE
-	Fl_PNG_Image(NULL, texture_azure32_png_buffer, 107)   // TX_AZURE
+	{NULL, texture_red32_png_buffer, 107},    // TX_RED
+	{NULL, texture_green32_png_buffer, 107},  // TX_GREEN
+	{NULL, texture_blue32_png_buffer, 107},   // TX_BLUE
+	{NULL, texture_purple32_png_buffer, 107}, // TX_PURPLE
+	{NULL, texture_orange32_png_buffer, 107}, // TX_ORANGE
+	{NULL, texture_azure32_png_buffer, 107}   // TX_AZURE
 };
 
 Event::Event(int8_t event_x, int8_t event_y, char s, EventTexture t, std::string line) : Fl_Box(0, 0, 0, 0),
@@ -155,7 +155,7 @@ void Event::draw() {
 	Main_Window *mw = (Main_Window *)user_data();
 	if (mw->mode() != Mode::EVENTS && !mw->show_events()) { return; }
 	int X = x(), Y = y(), W = w(), H = h();
-	boolean zoom = mw->zoom();
+	bool zoom = mw->zoom();
 	(zoom ? zoomed_texture_images : texture_images)[_texture].draw(X, Y, W, H);
 	fl_font(FL_HELVETICA_BOLD, zoom ? 24 : 14);
 	fl_color(FL_WHITE);

--- a/src/map-events.cpp
+++ b/src/map-events.cpp
@@ -4,7 +4,7 @@
 #include <unordered_map>
 
 #pragma warning(push, 0)
-#include <FL/fl_utf8.H>
+#include <FL/fl_utf8.h>
 #pragma warning(pop)
 
 #include "map-events.h"


### PR DESCRIPTION
Using the C++11 unified initialization syntax for Fl_PNG_Image seems to work properly.

Thanks to Qualopec on Discord for pointing this out, and Mathias for reporting the bug.